### PR TITLE
Added load_paths for @import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,11 +250,10 @@ pub fn from_string(p: String) -> std::result::Result<String, JsValue> {
         .map_err(|e| raw_to_parse_error(&map, *e).to_string())?)
 }
 
-
 #[cfg_attr(feature = "profiling", inline(never))]
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]
-pub fn from_path_with_load_paths(p: &str, loadpaths: Vec<&Path>) -> Result<String> {
+pub fn from_path_with_load_paths(p: &str, loadpaths: &Vec<&Path>) -> Result<String> {
     let mut map = CodeMap::new();
     let file = map.add_file(p.into(), String::from_utf8(fs::read(p)?)?);
     let empty_span = file.span.subspan(0, 0);
@@ -276,7 +275,7 @@ pub fn from_path_with_load_paths(p: &str, loadpaths: Vec<&Path>) -> Result<Strin
         at_root_has_selector: false,
         extender: &mut Extender::new(empty_span),
         content_scopes: &mut Scopes::new(),
-        load_paths: &loadpaths,
+        load_paths: loadpaths,
     }
     .parse()
     .map_err(|e| raw_to_parse_error(&map, *e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,13 @@ fn raw_to_parse_error(map: &CodeMap, err: Error) -> Box<Error> {
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]
 pub fn from_path(p: &str) -> Result<String> {
+    from_paths(p, &Vec::new())
+}
+
+#[cfg_attr(feature = "profiling", inline(never))]
+#[cfg_attr(not(feature = "profiling"), inline)]
+#[cfg(not(feature = "wasm"))]
+pub fn from_paths(p: &str, loadpaths: &[&Path]) -> Result<String> {
     let mut map = CodeMap::new();
     let file = map.add_file(p.into(), String::from_utf8(fs::read(p)?)?);
     let empty_span = file.span.subspan(0, 0);
@@ -161,7 +168,7 @@ pub fn from_path(p: &str) -> Result<String> {
         at_root_has_selector: false,
         extender: &mut Extender::new(empty_span),
         content_scopes: &mut Scopes::new(),
-        load_paths: &Vec::new(),
+        load_paths: loadpaths,
     }
     .parse()
     .map_err(|e| raw_to_parse_error(&map, *e))?;
@@ -171,7 +178,6 @@ pub fn from_path(p: &str) -> Result<String> {
         .pretty_print(&map)
         .map_err(|e| raw_to_parse_error(&map, *e))
 }
-
 /// Compile CSS from a string
 ///
 /// ```
@@ -248,40 +254,4 @@ pub fn from_string(p: String) -> std::result::Result<String, JsValue> {
         .map_err(|e| raw_to_parse_error(&map, *e).to_string())?
         .pretty_print(&map)
         .map_err(|e| raw_to_parse_error(&map, *e).to_string())?)
-}
-
-#[cfg_attr(feature = "profiling", inline(never))]
-#[cfg_attr(not(feature = "profiling"), inline)]
-#[cfg(not(feature = "wasm"))]
-pub fn from_path_with_load_paths(p: &str, loadpaths: &[&Path]) -> Result<String> {
-    let mut map = CodeMap::new();
-    let file = map.add_file(p.into(), String::from_utf8(fs::read(p)?)?);
-    let empty_span = file.span.subspan(0, 0);
-
-    let stmts = Parser {
-        toks: &mut Lexer::new(&file)
-            .collect::<Vec<Token>>()
-            .into_iter()
-            .peekmore(),
-        map: &mut map,
-        path: p.as_ref(),
-        scopes: &mut Scopes::new(),
-        global_scope: &mut Scope::new(),
-        super_selectors: &mut NeverEmptyVec::new(Selector::new(empty_span)),
-        span_before: empty_span,
-        content: &mut Vec::new(),
-        flags: ContextFlags::empty(),
-        at_root: true,
-        at_root_has_selector: false,
-        extender: &mut Extender::new(empty_span),
-        content_scopes: &mut Scopes::new(),
-        load_paths: loadpaths,
-    }
-    .parse()
-    .map_err(|e| raw_to_parse_error(&map, *e))?;
-
-    Css::from_stmts(stmts, false)
-        .map_err(|e| raw_to_parse_error(&map, *e))?
-        .pretty_print(&map)
-        .map_err(|e| raw_to_parse_error(&map, *e))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@ pub struct Options<'a> {
 /// - <https://sass-lang.com/documentation/at-rules/import#finding-the-file>
 /// - <https://sass-lang.com/documentation/at-rules/import#load-paths>
 impl<'a> Default for Options<'a> {
-    
     #[inline]
     fn default() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,16 @@ pub fn from_path(p: &str) -> Result<String> {
     from_paths(p, &Vec::new())
 }
 
+/// Compile CSS from a file and load in additional files through importing them
+/// note: @use is currently unsupported
+///
+/// ```
+/// fn main() -> Result<(), Box<grass::Error>> {
+///     let sass = grass::from_paths("input.scss", &[std::path::Path::new("benches")])?;
+///     Ok(())
+/// }
+/// ```
+/// (grass does not currently allow files or paths that are not valid UTF-8)
 #[cfg_attr(feature = "profiling", inline(never))]
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ pub struct Options<'a> {
 /// - <https://sass-lang.com/documentation/at-rules/import#finding-the-file>
 /// - <https://sass-lang.com/documentation/at-rules/import#load-paths>
 impl<'a> Default for Options<'a> {
+    
+    #[inline]
     fn default() -> Self {
         Self {
             style: OutputStyle::Expanded,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ impl<'a> Default for Options<'a> {
     }
 }
 
+#[allow(clippy::missing_const_for_fn)]
 impl<'a> Options<'a> {
     /// `grass` currently offers 2 different output styles
     ///
@@ -161,32 +162,43 @@ impl<'a> Options<'a> {
     ///  - `OutputStyle::Compressed` removes as many extra characters as possible, and writes the entire stylesheet on a single line.
     ///
     /// By default, output is expanded.
+    #[must_use]
+    #[inline]
     pub fn style(mut self, style: OutputStyle) -> Self {
         self.style = style;
         self
     }
 
+    #[must_use]
+    #[inline]
     pub fn quiet(mut self, quiet: bool) -> Self {
         self.quiet = quiet;
         self
     }
 
+    #[must_use]
+    #[inline]
     pub fn load_path(mut self, path: &'a Path) -> Self {
         self.load_paths.push(path);
         self
     }
 
     /// adds on to the `load_path` vec, does not set the vec to paths
+    #[must_use]
+    #[inline]
     pub fn load_paths(mut self, paths: &'a [&'a Path]) -> Self {
         self.load_paths.extend_from_slice(paths);
         self
     }
-
+    #[must_use]
+    #[inline]
     pub fn allows_charset(mut self, allows_charset: bool) -> Self {
         self.allows_charset = allows_charset;
         self
     }
 
+    #[must_use]
+    #[inline]
     pub fn unicode_error_messages(mut self, unicode_error_messages: bool) -> Self {
         self.unicode_error_messages = unicode_error_messages;
         self
@@ -210,7 +222,7 @@ fn raw_to_parse_error(map: &CodeMap, err: Error) -> Box<Error> {
 #[cfg_attr(feature = "profiling", inline(never))]
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]
-pub fn from_path(p: &str, options: &'_ Options<'_>) -> Result<String> {
+pub fn from_path(p: &str, options: &Options) -> Result<String> {
     let mut map = CodeMap::new();
     let file = map.add_file(p.into(), String::from_utf8(fs::read(p)?)?);
     let empty_span = file.span.subspan(0, 0);
@@ -255,7 +267,7 @@ pub fn from_path(p: &str, options: &'_ Options<'_>) -> Result<String> {
 #[cfg_attr(feature = "profiling", inline(never))]
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]
-pub fn from_string(p: String, options: &'_ Options<'_>) -> Result<String> {
+pub fn from_string(p: String, options: &Options) -> Result<String> {
     let mut map = CodeMap::new();
     let file = map.add_file("stdin".into(), p);
     let empty_span = file.span.subspan(0, 0);
@@ -311,6 +323,7 @@ pub fn from_string(p: String, options: &'_ Options<'_>) -> std::result::Result<S
         at_root_has_selector: false,
         extender: &mut Extender::new(empty_span),
         content_scopes: &mut Scopes::new(),
+        options,
     }
     .parse()
     .map_err(|e| raw_to_parse_error(&map, *e).to_string())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub fn from_string(p: String) -> std::result::Result<String, JsValue> {
 #[cfg_attr(feature = "profiling", inline(never))]
 #[cfg_attr(not(feature = "profiling"), inline)]
 #[cfg(not(feature = "wasm"))]
-pub fn from_path_with_load_paths(p: &str, loadpaths: &Vec<&Path>) -> Result<String> {
+pub fn from_path_with_load_paths(p: &str, loadpaths: &[&Path]) -> Result<String> {
     let mut map = CodeMap::new();
     let file = map.add_file(p.into(), String::from_utf8(fs::read(p)?)?);
     let empty_span = file.span.subspan(0, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> std::io::Result<()> {
         if let Some(path) = matches.value_of("OUTPUT") {
             let mut buf = BufWriter::new(File::open(path).unwrap_or(File::create(path)?));
             buf.write_all(
-                from_path_with_load_paths(name, vals)
+                from_path_with_load_paths(name, &vals)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)
@@ -203,7 +203,7 @@ fn main() -> std::io::Result<()> {
         } else {
             let mut stdout = BufWriter::new(stdout());
             stdout.write_all(
-                from_path_with_load_paths(name, vals)
+                from_path_with_load_paths(name, &vals)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::{arg_enum, App, AppSettings, Arg};
 
 #[cfg(not(feature = "wasm"))]
-use grass::from_paths;
+use grass::{from_path, Options};
 
 arg_enum! {
     #[derive(PartialEq, Debug)]
@@ -189,11 +189,13 @@ fn main() -> std::io::Result<()> {
         vals = Vec::new();
     }
 
+    let options = &Options::default().load_paths(&vals);
+
     if let Some(name) = matches.value_of("INPUT") {
         if let Some(path) = matches.value_of("OUTPUT") {
             let mut buf = BufWriter::new(File::open(path).unwrap_or(File::create(path)?));
             buf.write_all(
-                from_paths(name, &vals)
+                from_path(name, &options)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)
@@ -203,7 +205,7 @@ fn main() -> std::io::Result<()> {
         } else {
             let mut stdout = BufWriter::new(stdout());
             stdout.write_all(
-                from_paths(name, &vals)
+                from_path(name, &options)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::{arg_enum, App, AppSettings, Arg};
 
 #[cfg(not(feature = "wasm"))]
-use grass::from_path_with_load_paths;
+use grass::from_paths;
 
 arg_enum! {
     #[derive(PartialEq, Debug)]
@@ -193,7 +193,7 @@ fn main() -> std::io::Result<()> {
         if let Some(path) = matches.value_of("OUTPUT") {
             let mut buf = BufWriter::new(File::open(path).unwrap_or(File::create(path)?));
             buf.write_all(
-                from_path_with_load_paths(name, &vals)
+                from_paths(name, &vals)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)
@@ -203,7 +203,7 @@ fn main() -> std::io::Result<()> {
         } else {
             let mut stdout = BufWriter::new(stdout());
             stdout.write_all(
-                from_path_with_load_paths(name, &vals)
+                from_paths(name, &vals)
                     .unwrap_or_else(|e| {
                         eprintln!("{}", e);
                         std::process::exit(1)

--- a/src/parse/control_flow.rs
+++ b/src/parse/control_flow.rs
@@ -52,7 +52,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
-                load_paths: self.load_paths,
+                options: self.options,
             }
             .parse_stmt()?;
         } else {
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
                                 at_root_has_selector: self.at_root_has_selector,
                                 extender: self.extender,
                                 content_scopes: self.content_scopes,
-                                load_paths: self.load_paths,
+                                options: self.options,
                             }
                             .parse_stmt()?;
                         } else {
@@ -139,7 +139,7 @@ impl<'a> Parser<'a> {
                                 at_root_has_selector: self.at_root_has_selector,
                                 extender: self.extender,
                                 content_scopes: self.content_scopes,
-                                load_paths: self.load_paths,
+                                options: self.options,
                             }
                             .parse_stmt();
                         }
@@ -319,7 +319,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
-                    load_paths: self.load_paths,
+                    options: self.options,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -341,7 +341,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
-                        load_paths: self.load_paths,
+                        options: self.options,
                     }
                     .parse()?,
                 );
@@ -391,7 +391,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
-                    load_paths: self.load_paths,
+                    options: self.options,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -413,7 +413,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
-                        load_paths: self.load_paths,
+                        options: self.options,
                     }
                     .parse()?,
                 );
@@ -516,7 +516,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
-                    load_paths: self.load_paths,
+                    options: self.options,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -538,7 +538,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
-                        load_paths: self.load_paths,
+                        options: self.options,
                     }
                     .parse()?,
                 );

--- a/src/parse/control_flow.rs
+++ b/src/parse/control_flow.rs
@@ -52,6 +52,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
+                load_paths: self.load_paths,
             }
             .parse_stmt()?;
         } else {
@@ -110,6 +111,7 @@ impl<'a> Parser<'a> {
                                 at_root_has_selector: self.at_root_has_selector,
                                 extender: self.extender,
                                 content_scopes: self.content_scopes,
+                                load_paths: self.load_paths,
                             }
                             .parse_stmt()?;
                         } else {
@@ -137,6 +139,7 @@ impl<'a> Parser<'a> {
                                 at_root_has_selector: self.at_root_has_selector,
                                 extender: self.extender,
                                 content_scopes: self.content_scopes,
+                                load_paths: self.load_paths,
                             }
                             .parse_stmt();
                         }
@@ -316,6 +319,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
+                    load_paths: self.load_paths,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -337,6 +341,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
+                        load_paths: self.load_paths,
                     }
                     .parse()?,
                 );
@@ -386,6 +391,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
+                    load_paths: self.load_paths,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -407,6 +413,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
+                        load_paths: self.load_paths,
                     }
                     .parse()?,
                 );
@@ -509,6 +516,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.content_scopes,
+                    load_paths: self.load_paths,
                 }
                 .parse()?;
                 if !these_stmts.is_empty() {
@@ -530,6 +538,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
+                        load_paths: self.load_paths,
                     }
                     .parse()?,
                 );

--- a/src/parse/function.rs
+++ b/src/parse/function.rs
@@ -107,6 +107,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse()?;
 

--- a/src/parse/function.rs
+++ b/src/parse/function.rs
@@ -107,7 +107,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse()?;
 

--- a/src/parse/function.rs
+++ b/src/parse/function.rs
@@ -107,7 +107,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse()?;
 

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -9,8 +9,8 @@ use super::{Parser, Stmt};
 
 /// Searches the current directory of the file then searches in load paths directories
 /// if the import has not yet been found.
-/// [https://sass-lang.com/documentation/at-rules/import#finding-the-file](finding a file)
-/// [https://sass-lang.com/documentation/at-rules/import#load-paths](load path)
+/// <https://sass-lang.com/documentation/at-rules/import#finding-the-file>
+/// <https://sass-lang.com/documentation/at-rules/import#load-paths>
 fn find_import(file_path: &PathBuf, name: &OsStr, load_paths: &[&Path]) -> Option<PathBuf> {
     let paths = [
         file_path.with_file_name(name).with_extension("scss"),

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, fs, path::Path};
+use std::{ffi::OsStr, fs, path::Path, path::PathBuf};
 
 use codemap::Spanned;
 use peekmore::PeekMore;
@@ -98,24 +98,23 @@ impl<'a> Parser<'a> {
         }
 
         for path in self.load_paths {
-            let paths;
-            if path.is_dir() {
-                paths = vec![
+            let paths: Vec<PathBuf> = if path.is_dir() {
+                vec![
                     path.join(format!("{}.scss", name.to_str().unwrap())),
                     path.join(format!("_{}.scss", name.to_str().unwrap())),
                     path.join("index.scss"),
                     path.join("_index.scss"),
-                ];
+                ]
             } else {
-                paths = vec![
+                vec![
                     path.to_path_buf(),
                     path.with_file_name(name).with_extension("scss"),
                     path.with_file_name(format!("_{}", name.to_str().unwrap()))
                         .with_extension("scss"),
                     path.join("index.scss"),
                     path.join("_index.scss"),
-                ];
-            }
+                ]
+            };
 
             for name in &paths {
                 if name.is_file() {

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -7,6 +7,56 @@ use crate::{common::QuoteKind, error::SassResult, lexer::Lexer, value::Value, To
 
 use super::{Parser, Stmt};
 
+/// Searches the current directory of the file then searches in load paths directories
+/// if the import has not yet been found.
+/// [https://sass-lang.com/documentation/at-rules/import#finding-the-file](finding a file)
+/// [https://sass-lang.com/documentation/at-rules/import#load-paths](load path)
+fn find_import(file_path: &PathBuf, name: &OsStr, load_paths: &[&Path]) -> Option<PathBuf> {
+    let paths = [
+        file_path.with_file_name(name).with_extension("scss"),
+        file_path
+            .with_file_name(format!("_{}", name.to_str().unwrap()))
+            .with_extension("scss"),
+        file_path.clone(),
+        file_path.join("index.scss"),
+        file_path.join("_index.scss"),
+    ];
+
+    for name in &paths {
+        if name.is_file() {
+            return Some(name.to_path_buf());
+        }
+    }
+
+    for path in load_paths {
+        let paths: Vec<PathBuf> = if path.is_dir() {
+            vec![
+                path.join(format!("{}.scss", name.to_str().unwrap())),
+                path.join(format!("_{}.scss", name.to_str().unwrap())),
+                path.join("index.scss"),
+                path.join("_index.scss"),
+            ]
+        } else {
+            vec![
+                path.to_path_buf(),
+                path.with_file_name(name).with_extension("scss"),
+                path.with_file_name(format!("_{}", name.to_str().unwrap()))
+                    .with_extension("scss"),
+                path.join("index.scss"),
+                path.join("_index.scss"),
+            ]
+        };
+
+        for name in paths {
+            if name.is_file() {
+                return Some(name);
+            }
+        }
+    }
+
+    None
+}
+
 impl<'a> Parser<'a> {
     pub(super) fn import(&mut self) -> SassResult<Vec<Stmt>> {
         self.whitespace();
@@ -57,95 +107,32 @@ impl<'a> Parser<'a> {
 
         let name = path_buf.file_name().unwrap_or_else(|| OsStr::new(".."));
 
-        let paths = [
-            path_buf.with_file_name(name).with_extension("scss"),
-            path_buf
-                .with_file_name(format!("_{}", name.to_str().unwrap()))
-                .with_extension("scss"),
-            path_buf.clone(),
-            path_buf.join("index.scss"),
-            path_buf.join("_index.scss"),
-        ];
+        if let Some(name) = find_import(&path_buf, name, self.load_paths) {
+            let file = self.map.add_file(
+                name.to_string_lossy().into(),
+                String::from_utf8(fs::read(&name)?)?,
+            );
 
-        for name in &paths {
-            if name.is_file() {
-                let file = self.map.add_file(
-                    name.to_string_lossy().into(),
-                    String::from_utf8(fs::read(name)?)?,
-                );
-
-                return Parser {
-                    toks: &mut Lexer::new(&file)
-                        .collect::<Vec<Token>>()
-                        .into_iter()
-                        .peekmore(),
-                    map: self.map,
-                    path: name.as_ref(),
-                    scopes: self.scopes,
-                    global_scope: self.global_scope,
-                    super_selectors: self.super_selectors,
-                    span_before: file.span.subspan(0, 0),
-                    content: self.content,
-                    flags: self.flags,
-                    at_root: self.at_root,
-                    at_root_has_selector: self.at_root_has_selector,
-                    extender: self.extender,
-                    content_scopes: self.content_scopes,
-                    load_paths: self.load_paths,
-                }
-                .parse();
+            return Parser {
+                toks: &mut Lexer::new(&file)
+                    .collect::<Vec<Token>>()
+                    .into_iter()
+                    .peekmore(),
+                map: self.map,
+                path: &name,
+                scopes: self.scopes,
+                global_scope: self.global_scope,
+                super_selectors: self.super_selectors,
+                span_before: file.span.subspan(0, 0),
+                content: self.content,
+                flags: self.flags,
+                at_root: self.at_root,
+                at_root_has_selector: self.at_root_has_selector,
+                extender: self.extender,
+                content_scopes: self.content_scopes,
+                load_paths: self.load_paths,
             }
-        }
-
-        for path in self.load_paths {
-            let paths: Vec<PathBuf> = if path.is_dir() {
-                vec![
-                    path.join(format!("{}.scss", name.to_str().unwrap())),
-                    path.join(format!("_{}.scss", name.to_str().unwrap())),
-                    path.join("index.scss"),
-                    path.join("_index.scss"),
-                ]
-            } else {
-                vec![
-                    path.to_path_buf(),
-                    path.with_file_name(name).with_extension("scss"),
-                    path.with_file_name(format!("_{}", name.to_str().unwrap()))
-                        .with_extension("scss"),
-                    path.join("index.scss"),
-                    path.join("_index.scss"),
-                ]
-            };
-
-            for name in &paths {
-                if name.is_file() {
-                    println!("found file: {:?}", name);
-                    let file = self.map.add_file(
-                        name.to_string_lossy().into(),
-                        String::from_utf8(fs::read(name)?)?,
-                    );
-
-                    return Parser {
-                        toks: &mut Lexer::new(&file)
-                            .collect::<Vec<Token>>()
-                            .into_iter()
-                            .peekmore(),
-                        map: self.map,
-                        path: name.as_ref(),
-                        scopes: self.scopes,
-                        global_scope: self.global_scope,
-                        super_selectors: self.super_selectors,
-                        span_before: file.span.subspan(0, 0),
-                        content: self.content,
-                        flags: self.flags,
-                        at_root: self.at_root,
-                        at_root_has_selector: self.at_root_has_selector,
-                        extender: self.extender,
-                        content_scopes: self.content_scopes,
-                        load_paths: self.load_paths,
-                    }
-                    .parse();
-                }
-            }
+            .parse();
         }
 
         Err(("Can't find stylesheet to import.", span).into())

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -7,7 +7,7 @@ use crate::{common::QuoteKind, error::SassResult, lexer::Lexer, value::Value, To
 
 use super::{Parser, Stmt};
 
-/// Searches the current directory of the file then searches in load paths directories
+/// Searches the current directory of the file then searches in `load_paths` directories
 /// if the import has not yet been found.
 /// <https://sass-lang.com/documentation/at-rules/import#finding-the-file>
 /// <https://sass-lang.com/documentation/at-rules/import#load-paths>
@@ -107,7 +107,7 @@ impl<'a> Parser<'a> {
 
         let name = path_buf.file_name().unwrap_or_else(|| OsStr::new(".."));
 
-        if let Some(name) = find_import(&path_buf, name, self.load_paths) {
+        if let Some(name) = find_import(&path_buf, name, &self.options.load_paths) {
             let file = self.map.add_file(
                 name.to_string_lossy().into(),
                 String::from_utf8(fs::read(&name)?)?,
@@ -130,7 +130,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
-                load_paths: self.load_paths,
+                options: self.options,
             }
             .parse();
         }

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -97,24 +97,23 @@ impl<'a> Parser<'a> {
             }
         }
 
-        for _path in self.load_paths {
+        for path in self.load_paths {
             let paths;
-            if _path.is_dir() {
+            if path.is_dir() {
                 paths = vec![
-                    _path.join(format!("{}.scss", name.to_str().unwrap())),
-                    _path.join(format!("_{}.scss", name.to_str().unwrap())),
-                    _path.join("index.scss"),
-                    _path.join("_index.scss"),
+                    path.join(format!("{}.scss", name.to_str().unwrap())),
+                    path.join(format!("_{}.scss", name.to_str().unwrap())),
+                    path.join("index.scss"),
+                    path.join("_index.scss"),
                 ];
             } else {
                 paths = vec![
-                    _path.to_path_buf(),
-                    _path.with_file_name(name).with_extension("scss"),
-                    _path
-                        .with_file_name(format!("_{}", name.to_str().unwrap()))
+                    path.to_path_buf(),
+                    path.with_file_name(name).with_extension("scss"),
+                    path.with_file_name(format!("_{}", name.to_str().unwrap()))
                         .with_extension("scss"),
-                    _path.join("index.scss"),
-                    _path.join("_index.scss"),
+                    path.join("index.scss"),
+                    path.join("_index.scss"),
                 ];
             }
 

--- a/src/parse/keyframes.rs
+++ b/src/parse/keyframes.rs
@@ -165,7 +165,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
-                        load_paths: self.load_paths
+                        load_paths: self.load_paths,
                     })
                     .parse_keyframes_selector()?;
 
@@ -196,7 +196,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse_stmt()?;
 

--- a/src/parse/keyframes.rs
+++ b/src/parse/keyframes.rs
@@ -165,7 +165,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
-                        load_paths: self.load_paths,
+                        options: self.options,
                     })
                     .parse_keyframes_selector()?;
 
@@ -196,7 +196,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse_stmt()?;
 

--- a/src/parse/keyframes.rs
+++ b/src/parse/keyframes.rs
@@ -165,6 +165,7 @@ impl<'a> Parser<'a> {
                         at_root_has_selector: self.at_root_has_selector,
                         extender: self.extender,
                         content_scopes: self.content_scopes,
+                        load_paths: self.load_paths
                     })
                     .parse_keyframes_selector()?;
 
@@ -195,6 +196,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse_stmt()?;
 

--- a/src/parse/mixin.rs
+++ b/src/parse/mixin.rs
@@ -154,6 +154,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse()?;
 
@@ -205,6 +206,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.scopes,
+                    load_paths: self.load_paths
                 }
                 .parse()?
             } else {

--- a/src/parse/mixin.rs
+++ b/src/parse/mixin.rs
@@ -154,7 +154,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse()?;
 
@@ -206,7 +206,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.scopes,
-                    load_paths: self.load_paths,
+                    options: self.options,
                 }
                 .parse()?
             } else {

--- a/src/parse/mixin.rs
+++ b/src/parse/mixin.rs
@@ -154,7 +154,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse()?;
 
@@ -206,7 +206,7 @@ impl<'a> Parser<'a> {
                     at_root_has_selector: self.at_root_has_selector,
                     extender: self.extender,
                     content_scopes: self.scopes,
-                    load_paths: self.load_paths
+                    load_paths: self.load_paths,
                 }
                 .parse()?
             } else {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -83,7 +83,7 @@ pub(crate) struct Parser<'a> {
     pub at_root_has_selector: bool,
     pub extender: &'a mut Extender,
 
-    pub load_paths: &'a Vec<&'a Path>,
+    pub load_paths: &'a [&'a Path],
 }
 
 impl<'a> Parser<'a> {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -82,6 +82,8 @@ pub(crate) struct Parser<'a> {
     /// not the `@at-rule` block has a super selector
     pub at_root_has_selector: bool,
     pub extender: &'a mut Extender,
+
+    pub load_paths: &'a Vec<&'a Path>,
 }
 
 impl<'a> Parser<'a> {
@@ -359,6 +361,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
+                load_paths: self.load_paths
             },
             allows_parent,
             true,
@@ -597,6 +600,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse_stmt()?;
 
@@ -664,6 +668,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse()?
         .into_iter()
@@ -704,6 +709,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse_selector(false, true, String::new())?;
 
@@ -781,6 +787,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse_stmt()?;
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -17,11 +17,10 @@ use crate::{
     style::Style,
     utils::{read_until_closing_curly_brace, read_until_semicolon_or_closing_curly_brace},
     value::Value,
-    {Cow, Token},
+    Options, {Cow, Token},
 };
 
 use common::{Comment, ContextFlags, NeverEmptyVec, SelectorOrStyle};
-
 pub(crate) use value::{HigherIntermediateValue, ValueVisitor};
 
 mod args;
@@ -83,7 +82,7 @@ pub(crate) struct Parser<'a> {
     pub at_root_has_selector: bool,
     pub extender: &'a mut Extender,
 
-    pub load_paths: &'a [&'a Path],
+    pub options: &'a Options<'a>,
 }
 
 impl<'a> Parser<'a> {
@@ -361,7 +360,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
-                load_paths: self.load_paths,
+                options: self.options,
             },
             allows_parent,
             true,
@@ -600,7 +599,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse_stmt()?;
 
@@ -668,7 +667,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse()?
         .into_iter()
@@ -709,7 +708,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse_selector(false, true, String::new())?;
 
@@ -787,7 +786,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse_stmt()?;
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -361,7 +361,7 @@ impl<'a> Parser<'a> {
                 at_root_has_selector: self.at_root_has_selector,
                 extender: self.extender,
                 content_scopes: self.content_scopes,
-                load_paths: self.load_paths
+                load_paths: self.load_paths,
             },
             allows_parent,
             true,
@@ -600,7 +600,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse_stmt()?;
 
@@ -668,7 +668,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse()?
         .into_iter()
@@ -709,7 +709,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse_selector(false, true, String::new())?;
 
@@ -787,7 +787,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse_stmt()?;
 

--- a/src/parse/value/parse.rs
+++ b/src/parse/value/parse.rs
@@ -201,6 +201,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
+            load_paths: self.load_paths
         }
         .parse_value(in_paren)
     }

--- a/src/parse/value/parse.rs
+++ b/src/parse/value/parse.rs
@@ -201,7 +201,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths,
+            options: self.options,
         }
         .parse_value(in_paren)
     }

--- a/src/parse/value/parse.rs
+++ b/src/parse/value/parse.rs
@@ -201,7 +201,7 @@ impl<'a> Parser<'a> {
             at_root_has_selector: self.at_root_has_selector,
             extender: self.extender,
             content_scopes: self.content_scopes,
-            load_paths: self.load_paths
+            load_paths: self.load_paths,
         }
         .parse_value(in_paren)
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -476,7 +476,7 @@ impl Value {
             at_root_has_selector: parser.at_root_has_selector,
             extender: parser.extender,
             content_scopes: parser.content_scopes,
-            load_paths: parser.load_paths,
+            options: parser.options,
         }
         .parse_selector(allows_parent, true, String::new())
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -476,7 +476,7 @@ impl Value {
             at_root_has_selector: parser.at_root_has_selector,
             extender: parser.extender,
             content_scopes: parser.content_scopes,
-            load_paths: parser.load_paths
+            load_paths: parser.load_paths,
         }
         .parse_selector(allows_parent, true, String::new())
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -476,6 +476,7 @@ impl Value {
             at_root_has_selector: parser.at_root_has_selector,
             extender: parser.extender,
             content_scopes: parser.content_scopes,
+            load_paths: parser.load_paths
         }
         .parse_selector(allows_parent, true, String::new())
     }

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -44,7 +44,7 @@ fn imports_variable() {
     tempfile!("imports_variable", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 
@@ -59,7 +59,7 @@ fn import_no_semicolon() {
 fn import_no_quotes() {
     let input = "@import import_no_quotes";
     tempfile!("import_no_quotes", "$a: red;");
-    match grass::from_string(input.to_string()) {
+    match grass::from_string(input.to_string(), &grass::Options::default()) {
         Ok(..) => panic!("did not fail"),
         Err(e) => assert_eq!(
             "Error: Expected string.",
@@ -78,7 +78,7 @@ fn single_quotes_import() {
     tempfile!("single_quotes_import", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 
@@ -88,7 +88,7 @@ fn finds_name_scss() {
     tempfile!("finds_name_scss.scss", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 
@@ -98,7 +98,7 @@ fn finds_underscore_name_scss() {
     tempfile!("_finds_underscore_name_scss.scss", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 
@@ -110,7 +110,7 @@ fn chained_imports() {
     tempfile!("chained_imports__c.scss", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 
@@ -129,7 +129,7 @@ fn chained_imports_in_directory() {
     tempfile!("chained_imports_in_directory__c.scss", "$a: red;");
     assert_eq!(
         "a {\n  color: red;\n}\n",
-        &grass::from_string(input.to_string()).expect(input)
+        &grass::from_string(input.to_string(), &grass::Options::default()).expect(input)
     );
 }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,7 +7,7 @@ macro_rules! test {
         #[test]
         #[allow(non_snake_case)]
         fn $func() {
-            let sass = grass::from_string($input.to_string())
+            let sass = grass::from_string($input.to_string(), &grass::Options::default())
                 .expect(concat!("failed to parse on ", $input));
             assert_eq!(
                 String::from($input),
@@ -20,7 +20,7 @@ macro_rules! test {
         #[test]
         #[allow(non_snake_case)]
         fn $func() {
-            let sass = grass::from_string($input.to_string())
+            let sass = grass::from_string($input.to_string(), &grass::Options::default())
                 .expect(concat!("failed to parse on ", $input));
             assert_eq!(
                 String::from($output),
@@ -39,7 +39,7 @@ macro_rules! error {
         #[test]
         #[allow(non_snake_case)]
         fn $func() {
-            match grass::from_string($input.to_string()) {
+            match grass::from_string($input.to_string(), &grass::Options::default()) {
                 Ok(..) => panic!("did not fail"),
                 Err(e) => assert_eq!($err, e.to_string()
                                                 .chars()


### PR DESCRIPTION
Added support for loading multiple another directories by following: https://sass-lang.com/documentation/at-rules/import#load-paths

I am still a bit new to Rust so I hope this the best way to store the load_paths data but would love to learn a better way :) 