### PR TITLE
bump lasso 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ beef = "0.4.4"
 # long to compile, and you cannot make dev-dependencies optional
 criterion = { version = "0.3.2", optional = true }
 indexmap = "1.4.0"
-lasso = "0.2.2"
+lasso = "0.3.0"
 
 [features]
 default = ["commandline", "random"]


### PR DESCRIPTION
lasso 0.3 is more memory efficient https://github.com/Kixiron/lasso/blob/master/Changelog.md#030---2020-07-12
there is also `get_or_intern_static` but does not look useful for us.

@connorskees you might want to try and see if there are any regression. (I saw number of allocations goes up)