### PR TITLE
Compressed output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod utils;
 mod value;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum OutputStyle {
     /// The default style, this mode writes each
     /// selector and declaration on its own line.
@@ -313,7 +313,7 @@ pub fn from_path(p: &str, options: &Options) -> Result<String> {
 
     Css::from_stmts(stmts, false, options.allows_charset)
         .map_err(|e| raw_to_parse_error(&map, *e, options.unicode_error_messages))?
-        .pretty_print(&map)
+        .pretty_print(&map, options.style)
         .map_err(|e| raw_to_parse_error(&map, *e, options.unicode_error_messages))
 }
 
@@ -359,7 +359,7 @@ pub fn from_string(p: String, options: &Options) -> Result<String> {
 
     Css::from_stmts(stmts, false, options.allows_charset)
         .map_err(|e| raw_to_parse_error(&map, *e, options.unicode_error_messages))?
-        .pretty_print(&map)
+        .pretty_print(&map, options.style)
         .map_err(|e| raw_to_parse_error(&map, *e, options.unicode_error_messages))
 }
 
@@ -396,6 +396,6 @@ pub fn from_string(p: String) -> std::result::Result<String, JsValue> {
 
     Ok(Css::from_stmts(stmts, false, true)
         .map_err(|e| raw_to_parse_error(&map, *e, true).to_string())?
-        .pretty_print(&map)
+        .pretty_print(&map, options.style)
         .map_err(|e| raw_to_parse_error(&map, *e, true).to_string())?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,9 @@ use std::{
 use clap::{arg_enum, App, AppSettings, Arg};
 
 #[cfg(not(feature = "wasm"))]
-use grass::{from_path, from_string, Options};
+use grass::{from_path, from_string, Options, OutputStyle};
 
+// TODO remove this
 arg_enum! {
     #[derive(PartialEq, Debug)]
     pub enum Style {
@@ -58,11 +59,10 @@ fn main() -> std::io::Result<()> {
         )
         .arg(
             Arg::with_name("STYLE")
-                .short("s")
                 // this is required for compatibility with ruby sass
-                .short("t")
+                .short("t") // FIXME change this to short_alias later
+                .short("s")
                 .long("style")
-                .hidden(true)
                 .help("Minified or expanded output")
                 .default_value("expanded")
                 .case_insensitive(true)
@@ -183,8 +183,15 @@ fn main() -> std::io::Result<()> {
         .values_of("LOAD_PATH")
         .map_or_else(Vec::new, |vals| vals.map(Path::new).collect());
 
+    let style = match matches.value_of("STYLE").unwrap() {
+        "expanded" => OutputStyle::Expanded,
+        "compressed" => OutputStyle::Compressed,
+        _ => unreachable!(),
+    };
+
     let options = &Options::default()
         .load_paths(&load_paths)
+        .style(style)
         .quiet(matches.is_present("QUIET"))
         .unicode_error_messages(!matches.is_present("NO_UNICODE"))
         .allows_charset(!matches.is_present("NO_CHARSET"));


### PR DESCRIPTION
```
> cargo run -- bootstrap/scss/bootstrap.css | wc
   9519   18893  179725
> cargo run -- bootstrap/scss/bootstrap.css -s compressed | wc
      6    3270  145824
> /usr/bin/sass -s compressed bootstrap/scss/bootstrap.css | wc
      6    3149  145050
```

We are getting there, output sample from bootstrap from terminal.
```css
...
lock !important}.d-lg-block{display:block !important}.d-lg-table{display:table !importa
nt}.d-lg-table-row{display:table-row !important}.d-lg-table-cell{display:table-cell !im
portant}.d-lg-flex{display:flex !important}.d-lg-inline-flex{display:inline-flex !impor
tant}.flex-lg-fill{flex:1 1 auto !important}.flex-lg-row{flex-direction:row !important}
.flex-lg-column{flex-direction:column !important}.flex-lg-row-reverse{flex-direction:ro
w-reverse !important}.flex-lg-column-reverse{flex-direction:column-reverse !important}.
flex-lg-grow-0{flex-grow:0 !important}.flex-lg-grow-1{flex-grow:1 !important}.flex-lg-s
hrink-0{flex-shrink:0 !important}.flex-lg-shrink-1{flex-shrink:1 !important}.flex-lg-wr
ap{flex-wrap:wrap !important}.flex-lg-nowrap{flex-wrap:nowrap !important}.flex-lg-wrap-
reverse{flex-wrap:wrap-reverse !important}.justify-content-lg-start{justify-content:fle
x-start !important}.justify-content-lg-end{justify-content:flex-end !important}.justify
-content-lg-center{justify-content:center !important}.justify-content-lg-between{justif
y-content:space-between !important}.justify-content-lg-around{justify-content:space-aro
und !important}.justify-content-lg-evenly{justify-content:space-evenly !important}.alig
n-items-lg-start{align-items:flex-start !important}.align-items-lg-end{align-items:flex
-end !important}.align-items-lg-center{align-items:center !important}.align-items-lg-ba
seline{align-items:baseline !important}.align-items-lg-stretch{align-items:stretch !imp
ortant}.align-content-lg-start{align-content:flex-start !important}.align-content-lg-en
d{align-content:flex-end !important}.align-content-lg-center{align-content:center !impo
rtant}.align-content-lg-between{align-content:space-between !important}.align-content-l
g-around{align-content:space-around !important}.align-content-lg-stretch{align-content:
stretch !important}.align-self-lg-auto{align-self:auto !important}.align-self-lg-start{
align-self:flex-start !important}.align-self-lg-end{align-self:flex-end !important}.ali
gn-self-lg-center{align-self:center !important}.align-self-lg-baseline{align-self:basel
ine !important}.align-self-lg-stretch{align-self:stretch !important}.order-lg-first{ord
er:-1 !important}.order-lg-0{order:0 !important}.order-lg-1{order:1 !important}.order-l
g-2{order:2 !important}.order-lg-3{order:3 !important}.order-lg-4{order:4 !important}.o
rder-lg-5{order:5 !important}.order-lg-last{order:6 !important}.m-lg-0{margin:0 !import
ant}.m-lg-1{margin:0.25rem !important}.m-lg-2{margin:0.5rem !important}.m-lg-3{margin:1
rem !important}.m-lg-4{margin:1.5rem !important}.m-lg-5{margin:3rem !important}.m-lg-au
to{margin:auto !important}.mx-lg-0{margin-right:0 !important;margin-left:0 !important}.
mx-lg-1{margin-right:0.25rem !important;margin-left:0.25rem !important}.mx-lg-2{margin-
right:0.5rem !important;margin-left:0.5rem !important}.mx-lg-3{margin-right:1rem !impor
tant;margin-left:1rem !important}.mx-lg-4{margin-right:1.5rem !important;margin-left:1.
...
```
Mainly `Style` ~and `Ruleset selector`~ still needs some change to reduce the space, ideally all `Display` should be taken to the `Formatter` rather than having a single `to_string` for both `Formatting`, maybe we should just remove all the `impl Display`.

Benchmark
```
> hyperfine 'target/release/grass bootstrap/scss/bootstrap.css -t compressed >/dev/null' 'target/release/grass bootstrap/scss/bootstrap.css -t expanded >/dev/null' '/usr/bin/sass -s compressed bootstrap/scss/bootstrap.css'
Benchmark #1: target/release/grass bootstrap/scss/bootstrap.css -t compressed >/dev/null
  Time (mean ± σ):      33.0 ms ±   2.8 ms    [User: 28.1 ms, System: 4.3 ms]
  Range (min … max):    30.3 ms …  39.4 ms    82 runs

Benchmark #2: target/release/grass bootstrap/scss/bootstrap.css -t expanded >/dev/null
  Time (mean ± σ):      34.9 ms ±   3.0 ms    [User: 30.4 ms, System: 4.1 ms]
  Range (min … max):    31.5 ms …  41.7 ms    86 runs

Benchmark #3: /usr/bin/sass -s compressed bootstrap/scss/bootstrap.css
  Time (mean ± σ):     111.6 ms ±   6.7 ms    [User: 104.3 ms, System: 18.3 ms]
  Range (min … max):   103.2 ms … 124.8 ms    27 runs

Summary
  'target/release/grass bootstrap/scss/bootstrap.css -t compressed >/dev/null' ran
    1.06 ± 0.13 times faster than 'target/release/grass bootstrap/scss/bootstrap.css -t expanded >/dev/null'
    3.38 ± 0.35 times faster than '/usr/bin/sass -s compressed bootstrap/scss/bootstrap.css'
```

Other area of improvements:
- [x] ` > `, ` < `, `~` and related stuff in selector
- [x] last semicolon in block
- [ ] colors block `, ` (we probably need to remove `color.repr`)
- [ ] `calc` block `, `
- [ ] decimal starting with `0.` (I need to ask for help for this)
