### PR TITLE
Overwrite output file if already present.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::File,
+    fs::OpenOptions,
     io::{stdin, stdout, BufWriter, Read, Write},
     path::Path,
 };
@@ -191,7 +191,13 @@ fn main() -> std::io::Result<()> {
 
     let (mut stdout_write, mut file_write);
     let buf_out: &mut dyn Write = if let Some(path) = matches.value_of("OUTPUT") {
-        file_write = BufWriter::new(File::open(path).unwrap_or(File::create(path)?));
+        file_write = BufWriter::new(
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(path)?,
+        );
         &mut file_write
     } else {
         stdout_write = BufWriter::new(stdout());


### PR DESCRIPTION
File::open() opens in read only mode. Has been modified to OpenOptions
to be able to both create the file if it doensn't exist, and truncate
and write if it does.

Fixes #34