### PR TITLE
Added additional steps to run the official spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cd grass
 cargo b --release
 ./sass-spec/sass-spec.rb -c './target/release/grass'
 ```
+Note: you will have to install [ruby](https://www.ruby-lang.org/en/downloads/), [bundler](https://bundler.io/) and run `bundle install` in `./sass-spec/`. This might also require you to install the requirements separately for [curses](https://github.com/ruby/curses)
 
 These numbers come from a default run of the Sass specification as shown above.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ cd grass
 cargo b --release
 ./sass-spec/sass-spec.rb -c './target/release/grass'
 ```
-Note: you will have to install [ruby](https://www.ruby-lang.org/en/downloads/), [bundler](https://bundler.io/) and run `bundle install` in `./sass-spec/`. This might also require you to install the requirements separately for [curses](https://github.com/ruby/curses)
+Note: you will have to install [ruby](https://www.ruby-lang.org/en/downloads/),
+[bundler](https://bundler.io/) and run `bundle install` in `./sass-spec/`.
+This might also require you to install the requirements separately
+for [curses](https://github.com/ruby/curses)
 
 These numbers come from a default run of the Sass specification as shown above.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo b --release
 Note: you will have to install [ruby](https://www.ruby-lang.org/en/downloads/),
 [bundler](https://bundler.io/) and run `bundle install` in `./sass-spec/`.
 This might also require you to install the requirements separately
-for [curses](https://github.com/ruby/curses)
+for [curses](https://github.com/ruby/curses).
 
 These numbers come from a default run of the Sass specification as shown above.
 


### PR DESCRIPTION
For people who know rust, but are not familiar with ruby, it might not be immediatly clear what to do to get the spec to run.
Added additional steps which might be needed for a developer to be able to run the specs.

I'm not familiar with ruby and some of the 'hidden' dependencies (i.e. curses) was not immediately clear about how it needed to be installed.