### PR TITLE
Created an initial comparative fuzzing target.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,3 +24,9 @@ doc = false
 name = "from_string_parsing"
 path = "fuzz_targets/from_string_parsing.rs"
 test = false
+
+[[bin]]
+doc = false
+name = "compare_with_dart_sass"
+path = "fuzz_targets/compare_with_dart_sass.rs"
+test = false

--- a/fuzz/fuzz_targets/compare_with_dart_sass.rs
+++ b/fuzz/fuzz_targets/compare_with_dart_sass.rs
@@ -1,0 +1,46 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let options = grass::Options::default();
+
+        let grass_result = grass::from_string(s.to_owned(), &options);
+        let sass_process_result = run_dart_sass(s);
+
+        if let Ok(sass_result) = sass_process_result {
+            if sass_result.status.success() != grass_result.is_ok() {
+                panic!(format!(
+                    r#"Difference in output between grass and sass for:
+
+{:?}
+
+dart sass succeeded:{}
+    grass succeeded:{}"#,
+                    s,
+                    sass_result.status.success(),
+                    grass_result.is_ok()
+                ));
+            }
+        }
+    }
+});
+
+fn run_dart_sass(input: &str) -> Result<std::process::Output, Box<dyn std::error::Error>> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("sass")
+        .arg("--stdin")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    {
+        let child_stdin = child.stdin.as_mut().unwrap();
+        child_stdin.write_all(input.as_bytes())?;
+    }
+
+    Ok(child.wait_with_output()?)
+}


### PR DESCRIPTION
Created a fuzzing target which compares `grass` with the npm `sass`

This is an initial suggestion. It only compares whether they both accept the input or both reject the input. It does not yet compare the result. It also runs a bit slow.

While it runs slow it already found a difference between them for: "\nJ*{" for example