### PR TITLE
Make the style match realy case insensitive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn main() -> std::io::Result<()> {
         .values_of("LOAD_PATH")
         .map_or_else(Vec::new, |vals| vals.map(Path::new).collect());
 
-    let style = match matches.value_of("STYLE").unwrap() {
+    let style = match &matches.value_of("STYLE").unwrap().to_lowercase() as &str {
         "expanded" => OutputStyle::Expanded,
         "compressed" => OutputStyle::Compressed,
         _ => unreachable!(),


### PR DESCRIPTION
When you run the command `grass --style Compressed` as one of the suggested options but then it fails:

```
thread 'main' panicked at 'internal error: entered unreachable code', /sysroot/home/johan.smits/.cargo/registry/src/github.com-1ecc6299db9ec823/grass-0.10.7/src/main.rs:189:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fish: 'grass --style Compressed src/sa…' terminated by signal SIGABRT (Abort)
```