### PR TITLE
Add profile to generate a small final binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ debug = true
 panic = "abort"
 lto = true
 codegen-units = 1
+
+[profile.small]
+opt-level = 'z'     # Optimize for size
+lto = true          # Enable link-time optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations
+panic = 'abort'     # Abort on panic
+strip = true        # Strip symbols from binary*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ lto = true
 codegen-units = 1
 
 [profile.small]
+inherits = 'release'
 opt-level = 'z'     # Optimize for size
 lto = true          # Enable link-time optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations


### PR DESCRIPTION
This should make it possible to cargo install --profile=small to generate a small binary. This is primarily useful in dockerfiles where this library is chosen primarily for the sake of being able to ship a tiny scss compiler (which is also still being noticeably faster than the "big" counterparts) among other useful web tools.