### PR TITLE
replace unmaintained actions-rs/* actions in CI workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
 
       - name: version info
         run: rustc --version; cargo --version;
@@ -30,16 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -47,16 +40,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args:  --features=macro -- -D warnings
+      - run: cargo clippy --features=macro -- -D warnings
 
   boostrap:
     runs-on: ubuntu-latest
@@ -64,11 +52,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Build
         run: cargo build
@@ -100,11 +86,9 @@ jobs:
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@master
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@master
   #       with:
-  #         profile: minimal
   #         toolchain: stable
-  #         override: true
   #     - name: version info
   #       run:  rustc --version; cargo --version;
   #     - name: Build binary


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/connorskees/grass/actions/runs/5033527383:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.