### PR TITLE
Fix `@forward` statement altering the scope of the forwarded module

### DIFF
--- a/crates/compiler/src/builtin/modules/mod.rs
+++ b/crates/compiler/src/builtin/modules/mod.rs
@@ -138,14 +138,15 @@ impl ForwardedModule {
             rule.hidden_mixins_and_functions.as_ref(),
         );
 
-        (*module).borrow_mut().set_scope(ModuleScope {
+        let mut inner = module.borrow().clone();
+        inner.set_scope(ModuleScope {
             variables,
             mixins,
             functions,
         });
 
         ForwardedModule {
-            inner: module,
+            inner: Arc::new(RefCell::new(inner)),
             forward_rule: rule,
         }
     }

--- a/crates/compiler/src/builtin/modules/mod.rs
+++ b/crates/compiler/src/builtin/modules/mod.rs
@@ -108,6 +108,8 @@ impl ShadowedModule {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ForwardedModule {
+    scope: ModuleScope,
+    #[allow(dead_code)]
     inner: Arc<RefCell<Module>>,
     #[allow(dead_code)]
     forward_rule: AstForwardRule,
@@ -138,16 +140,16 @@ impl ForwardedModule {
             rule.hidden_mixins_and_functions.as_ref(),
         );
 
-        let mut inner = module.borrow().clone();
-        inner.set_scope(ModuleScope {
+        let scope = ModuleScope {
             variables,
             mixins,
             functions,
-        });
+        };
 
         ForwardedModule {
-            inner: Arc::new(RefCell::new(inner)),
+            inner: module,
             forward_rule: rule,
+            scope,
         }
     }
 
@@ -363,17 +365,8 @@ impl Module {
         match self {
             Self::Builtin { scope }
             | Self::Environment { scope, .. }
+            | Self::Forwarded(ForwardedModule { scope, .. })
             | Self::Shadowed(ShadowedModule { scope, .. }) => scope.clone(),
-            Self::Forwarded(forwarded) => (*forwarded.inner).borrow().scope(),
-        }
-    }
-
-    fn set_scope(&mut self, new_scope: ModuleScope) {
-        match self {
-            Self::Builtin { scope }
-            | Self::Environment { scope, .. }
-            | Self::Shadowed(ShadowedModule { scope, .. }) => *scope = new_scope,
-            Self::Forwarded(forwarded) => (*forwarded.inner).borrow_mut().set_scope(new_scope),
         }
     }
 
@@ -403,10 +396,9 @@ impl Module {
             Self::Builtin { .. } => {
                 return Err(("Cannot modify built-in variable.", name.span).into())
             }
-            Self::Environment { scope, .. } | Self::Shadowed(ShadowedModule { scope, .. }) => {
-                scope.clone()
-            }
-            Self::Forwarded(forwarded) => (*forwarded.inner).borrow_mut().scope(),
+            Self::Environment { scope, .. }
+            | Self::Forwarded(ForwardedModule { scope, .. })
+            | Self::Shadowed(ShadowedModule { scope, .. }) => scope.clone(),
         };
 
         if scope.variables.insert(name.node, value).is_none() {

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -72,9 +72,7 @@ pub use grass_compiler::{
 
 /// Include CSS in your binary at compile time from a Sass source file
 ///
-/// ```
-/// static CSS: &str = grass::include!("../static/_index.scss");
-/// ```
+/// `static CSS: &str = grass::include!("../static/_index.scss");`
 ///
 /// This requires the `"macro"` feature, which is not enabled by default.
 ///

--- a/crates/lib/src/main.rs
+++ b/crates/lib/src/main.rs
@@ -168,12 +168,14 @@ fn cli() -> Command {
         .arg(
             Arg::new("NO_COLOR")
                 .short('c')
+                .action(ArgAction::SetTrue)
                 .long("no-color")
                 .hide(true)
                 .help("Whether to use terminal colors for messages.")
         )
         .arg(
             Arg::new("VERBOSE")
+                .action(ArgAction::SetTrue)
                 .long("verbose")
                 .hide(true)
                 .help("Print all deprecation warnings even when they're repetitive.")

--- a/crates/lib/tests/forward.rs
+++ b/crates/lib/tests/forward.rs
@@ -501,6 +501,40 @@ fn import_forwarded_first_no_use() {
     );
 }
 
+#[test]
+fn forward_same_module_with_and_without_prefix() {
+    let mut fs = TestFs::new();
+
+    fs.add_file(
+        "_midstream.scss",
+        r#"
+            @forward "upstream";
+            @forward "upstream" as b-*;
+        "#,
+    );
+    fs.add_file(
+        "_upstream.scss",
+        r#"
+            @mixin a() {
+                c {
+                    d: e
+                }
+            }
+        "#,
+    );
+
+    let input = r#"
+        @use "midstream";
+
+        @include midstream.a;
+    "#;
+
+    assert_eq!(
+        "c {\n  d: e;\n}\n",
+        &grass::from_string(input.to_string(), &grass::Options::default().fs(&fs)).expect(input)
+    );
+}
+
 error!(
     after_style_rule,
     r#"


### PR DESCRIPTION
When using the @forward statement multiple times on the same module, there was an unintended mutation of the loaded module scope. Using `@forward "path" as prefix-*;` would change the scope for a module loaded without a prefix too or with a different prefix, resulting in errors such as "Undefined mixin" or "Undefined function".

I initially found the issue while trying to compile Carbon Design System SCSS style with grass.

The scope built for a particular forward statement in now directly included on the `ForwardedModule` type just like how its done for the `ShadowedModule` type.