### PR TITLE
Add logger trait

### DIFF
--- a/crates/compiler/src/evaluate/visitor.rs
+++ b/crates/compiler/src/evaluate/visitor.rs
@@ -1042,14 +1042,10 @@ impl<'a> Visitor<'a> {
         }
 
         let message = self.visit_expr(debug_rule.value)?;
+        let message = message.inspect(debug_rule.span)?;
 
         let loc = self.map.look_up_span(debug_rule.span);
-        eprintln!(
-            "{}:{} DEBUG: {}",
-            loc.file.name(),
-            loc.begin.line + 1,
-            message.inspect(debug_rule.span)?
-        );
+        self.options.logger.debug(loc, message.as_str());
 
         Ok(None)
     }
@@ -1588,13 +1584,7 @@ impl<'a> Visitor<'a> {
             return;
         }
         let loc = self.map.look_up_span(span);
-        eprintln!(
-            "Warning: {}\n    ./{}:{}:{}",
-            message,
-            loc.file.name(),
-            loc.begin.line + 1,
-            loc.begin.column + 1
-        );
+        self.options.logger.warning(loc, message);
     }
 
     fn visit_warn_rule(&mut self, warn_rule: AstWarn) -> SassResult<()> {

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -80,6 +80,7 @@ pub use crate::error::{
     PublicSassErrorKind as ErrorKind, SassError as Error, SassResult as Result,
 };
 pub use crate::fs::{Fs, NullFs, StdFs};
+pub use crate::logger::{Logger, NullLogger, StdLogger};
 pub use crate::options::{InputSyntax, Options, OutputStyle};
 pub use crate::{builtin::Builtin, evaluate::Visitor};
 pub(crate) use crate::{context_flags::ContextFlags, lexer::Token};
@@ -114,6 +115,7 @@ mod evaluate;
 mod fs;
 mod interner;
 mod lexer;
+mod logger;
 mod options;
 mod parse;
 mod selector;

--- a/crates/compiler/src/logger.rs
+++ b/crates/compiler/src/logger.rs
@@ -1,0 +1,50 @@
+use codemap::SpanLoc;
+use std::fmt::Debug;
+
+/// Sink for log messages
+pub trait Logger: Debug {
+    /// Logs message from a `@debug` statement
+    fn debug(&self, location: SpanLoc, message: &str);
+
+    /// Logs message from a `@warn` statement
+    fn warning(&self, location: SpanLoc, message: &str);
+}
+
+/// Logs events to standard error
+#[derive(Debug)]
+pub struct StdLogger;
+
+impl Logger for StdLogger {
+    #[inline]
+    fn debug(&self, location: SpanLoc, message: &str) {
+        eprintln!(
+            "{}:{} DEBUG: {}",
+            location.file.name(),
+            location.begin.line + 1,
+            message
+        );
+    }
+
+    #[inline]
+    fn warning(&self, location: SpanLoc, message: &str) {
+        eprintln!(
+            "Warning: {}\n    ./{}:{}:{}",
+            message,
+            location.file.name(),
+            location.begin.line + 1,
+            location.begin.column + 1
+        );
+    }
+}
+
+/// Discards all log events
+#[derive(Debug)]
+pub struct NullLogger;
+
+impl Logger for NullLogger {
+    #[inline]
+    fn debug(&self, _location: SpanLoc, _message: &str) {}
+
+    #[inline]
+    fn warning(&self, _location: SpanLoc, _message: &str) {}
+}

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -66,8 +66,8 @@ grass input.scss
 )]
 
 pub use grass_compiler::{
-    from_path, from_string, Error, ErrorKind, Fs, InputSyntax, NullFs, Options, OutputStyle,
-    Result, StdFs,
+    from_path, from_string, Error, ErrorKind, Fs, InputSyntax, Logger, NullFs, NullLogger, Options,
+    OutputStyle, Result, StdFs, StdLogger,
 };
 
 /// Include CSS in your binary at compile time from a Sass source file

--- a/crates/lib/tests/debug.rs
+++ b/crates/lib/tests/debug.rs
@@ -1,12 +1,37 @@
+use macros::TestLogger;
+
 #[macro_use]
 mod macros;
 
-test!(simple_debug, "@debug 2", "");
-test!(simple_debug_with_semicolon, "@debug 2;", "");
-test!(
-    // todo: test stdout
-    debug_while_quiet,
-    "@debug 2;",
-    "",
-    grass::Options::default().quiet(true)
-);
+#[test]
+fn simple_debug() {
+    let input = "@debug 2";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[String::from("2")], logger.debug_messages().as_slice());
+    assert_eq!(&[] as &[String], logger.warning_messages().as_slice());
+}
+
+#[test]
+fn simple_debug_with_semicolon() {
+    let input = "@debug 2;";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[String::from("2")], logger.debug_messages().as_slice());
+    assert_eq!(&[] as &[String], logger.warning_messages().as_slice());
+}
+
+#[test]
+fn debug_while_quiet() {
+    let input = "@debug 2;";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger).quiet(true);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[] as &[String], logger.debug_messages().as_slice());
+    assert_eq!(&[] as &[String], logger.warning_messages().as_slice());
+}

--- a/crates/lib/tests/warn.rs
+++ b/crates/lib/tests/warn.rs
@@ -1,11 +1,37 @@
+use macros::TestLogger;
+
 #[macro_use]
 mod macros;
 
-test!(simple_warn, "@warn 2", "");
-test!(
-    // todo: test stdout
-    warn_while_quiet,
-    "@warn 2;",
-    "",
-    grass::Options::default().quiet(true)
-);
+#[test]
+fn warn_debug() {
+    let input = "@warn 2";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[] as &[String], logger.debug_messages().as_slice());
+    assert_eq!(&[String::from("2")], logger.warning_messages().as_slice());
+}
+
+#[test]
+fn simple_warn_with_semicolon() {
+    let input = "@warn 2;";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[] as &[String], logger.debug_messages().as_slice());
+    assert_eq!(&[String::from("2")], logger.warning_messages().as_slice());
+}
+
+#[test]
+fn warn_while_quiet() {
+    let input = "@warn 2;";
+    let logger = TestLogger::default();
+    let options = grass::Options::default().logger(&logger).quiet(true);
+    let output = grass::from_string(input.to_string(), &options).expect(input);
+    assert_eq!(&output, "");
+    assert_eq!(&[] as &[String], logger.debug_messages().as_slice());
+    assert_eq!(&[] as &[String], logger.warning_messages().as_slice());
+}


### PR DESCRIPTION
Introduced a new `Logger` trait which can be used to access all log events emitted during compilation. Currently these only include messages emitted by the `@debug` and `@warn` statements.

Changes were implemented in a backwards-compatible manner, but the current `Options::quiet` method has been marked as deprecated, as its behavior can be achieved using the `NullLogger` structure. The default logger used is `StdLogger` which writes all log events to standard error. This reflect the default behavior prior to introduction of `Logger`.

With these new changes, it is also now possible to properly test the `@debug` and `@warn` statements.