### PR TITLE
Add custom global variables

### DIFF
--- a/crates/compiler/src/options.rs
+++ b/crates/compiler/src/options.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{builtin::Builtin, Fs, Logger, StdFs, StdLogger};
+use crate::{builtin::Builtin, value::Value, Fs, Logger, StdFs, StdLogger};
 
 /// Configuration for Sass compilation
 ///
@@ -20,6 +20,7 @@ pub struct Options<'a> {
     pub(crate) quiet: bool,
     pub(crate) input_syntax: Option<InputSyntax>,
     pub(crate) custom_fns: HashMap<String, Builtin>,
+    pub(crate) custom_vars: HashMap<String, Value>,
 }
 
 impl Default for Options<'_> {
@@ -35,6 +36,7 @@ impl Default for Options<'_> {
             quiet: false,
             input_syntax: None,
             custom_fns: HashMap::new(),
+            custom_vars: HashMap::new(),
         }
     }
 }
@@ -174,6 +176,13 @@ impl<'a> Options<'a> {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "custom-builtin-fns")))]
     pub fn add_custom_fn<S: Into<String>>(mut self, name: S, func: Builtin) -> Self {
         self.custom_fns.insert(name.into(), func);
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn add_custom_var<S: Into<String>>(mut self, name: S, value: Value) -> Self {
+        self.custom_vars.insert(name.into(), value);
         self
     }
 

--- a/crates/lib/tests/custom-global-variable.rs
+++ b/crates/lib/tests/custom-global-variable.rs
@@ -1,0 +1,20 @@
+use grass::{from_string, Options};
+use grass_compiler::sass_value::{QuoteKind, Value};
+
+#[test]
+fn lookup_custom_global_variable() {
+    let opts = Options::default().add_custom_var("x", Value::String("foo".into(), QuoteKind::None));
+    assert_eq!(
+        from_string("a {\n  test: $x;\n}\n", &opts).ok(),
+        Some("a {\n  test: foo;\n}\n".to_owned())
+    );
+}
+
+#[test]
+fn user_defined_takes_precedence_over_global_variable() {
+    let opts = Options::default().add_custom_var("x", Value::String("foo".into(), QuoteKind::None));
+    assert_eq!(
+        from_string("$x: bar;\na {\n  test: $x;\n}\n", &opts).ok(),
+        Some("a {\n  test: bar;\n}\n".to_owned())
+    );
+}


### PR DESCRIPTION
The existing custom functions require a function pointer, not a closure, which makes it difficult to inject variable data when creating the compiler options. This PR adds custom variables, which are a map of `String`s to `sass_value::Value`s which handles this use case.