### PR TITLE
feat: add OutputStyle::GtkCompressed

### DIFF
--- a/crates/compiler/src/options.rs
+++ b/crates/compiler/src/options.rs
@@ -61,11 +61,13 @@ impl<'a> Options<'a> {
         self
     }
 
-    /// `grass` currently offers 2 different output styles
+    /// `grass` currently offers 4 different output styles
     ///
     ///  - [`OutputStyle::Expanded`] writes each selector and declaration on its own line.
     ///  - [`OutputStyle::Compressed`] removes as many extra characters as possible
     ///    and writes the entire stylesheet on a single line.
+    ///  - [`OutputStyle::GtkCompressed`] mirrors [`OutputStyle::Compressed`]s style, while
+    ///    maintaining compatibility with GTK CSS.
     ///
     /// By default, output is expanded.
     #[must_use]
@@ -129,7 +131,9 @@ impl<'a> Options<'a> {
     /// By default, Sass will insert either a `@charset`
     /// declaration (in expanded output mode) or a byte-order
     /// mark (in compressed output mode) if the stylesheet
-    /// contains any non-ASCII characters.
+    /// contains any non-ASCII characters. In gtk-compressed mode
+    /// no charset is ever inserted, since gtk css already expects
+    /// all css to be utf-8.
     #[must_use]
     #[inline]
     pub const fn allows_charset(mut self, allows_charset: bool) -> Self {
@@ -178,7 +182,10 @@ impl<'a> Options<'a> {
     }
 
     pub(crate) fn is_compressed(&self) -> bool {
-        matches!(self.style, OutputStyle::Compressed)
+        matches!(
+            self.style,
+            OutputStyle::Compressed | OutputStyle::GtkCompressed
+        )
     }
 }
 
@@ -224,4 +231,7 @@ pub enum OutputStyle {
     /// Ideal for release builds, this mode removes as many extra characters as
     /// possible and writes the entire stylesheet on a single line.
     Compressed,
+
+    /// Like [`Self::Compressed`] but compatible with GTK CSS.
+    GtkCompressed,
 }

--- a/crates/compiler/src/options.rs
+++ b/crates/compiler/src/options.rs
@@ -61,7 +61,7 @@ impl<'a> Options<'a> {
         self
     }
 
-    /// `grass` currently offers 4 different output styles
+    /// `grass` currently offers 3 different output styles
     ///
     ///  - [`OutputStyle::Expanded`] writes each selector and declaration on its own line.
     ///  - [`OutputStyle::Compressed`] removes as many extra characters as possible

--- a/crates/compiler/src/serializer.rs
+++ b/crates/compiler/src/serializer.rs
@@ -16,7 +16,7 @@ use crate::{
         fuzzy_equals, ArgList, CalculationArg, CalculationName, SassCalculation, SassFunction,
         SassMap, SassNumber, Value,
     },
-    Options,
+    Options, OutputStyle,
 };
 
 pub(crate) fn serialize_selector_list(
@@ -646,9 +646,15 @@ impl<'a> Serializer<'a> {
         // SAFETY: todo
         let mut as_string = unsafe { String::from_utf8_unchecked(self.buffer) };
 
-        if is_not_ascii && self.options.is_compressed() && self.options.allows_charset {
+        if is_not_ascii
+            && self.options.style == OutputStyle::Compressed
+            && self.options.allows_charset
+        {
             as_string.insert(0, '\u{FEFF}');
-        } else if is_not_ascii && self.options.allows_charset {
+        } else if is_not_ascii
+            && self.options.allows_charset
+            && self.options.style != OutputStyle::GtkCompressed
+        {
             as_string.insert_str(0, "@charset \"UTF-8\";\n");
         }
 
@@ -1060,7 +1066,7 @@ impl<'a> Serializer<'a> {
             let did_write = self.visit_stmt(last)?;
 
             if did_write {
-                if needs_semicolon && !self.options.is_compressed() {
+                if needs_semicolon && self.options.style != OutputStyle::Compressed {
                     self.buffer.push(b';');
                 }
 

--- a/crates/lib/src/main.rs
+++ b/crates/lib/src/main.rs
@@ -12,17 +12,19 @@ use grass::{from_path, from_string, Options, OutputStyle};
 pub enum Style {
     Expanded,
     Compressed,
+    GtkCompressed,
 }
 
 impl ValueEnum for Style {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Expanded, Self::Compressed]
+        &[Self::Expanded, Self::Compressed, Self::GtkCompressed]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(match self {
             Self::Expanded => PossibleValue::new("expanded"),
             Self::Compressed => PossibleValue::new("compressed"),
+            Self::GtkCompressed => PossibleValue::new("gtk-compressed"),
         })
     }
 }
@@ -223,6 +225,7 @@ fn main() -> std::io::Result<()> {
     let style = match &matches.get_one::<Style>("STYLE").unwrap() {
         Style::Expanded => OutputStyle::Expanded,
         Style::Compressed => OutputStyle::Compressed,
+        Style::GtkCompressed => OutputStyle::GtkCompressed,
     };
 
     let options = &Options::default()

--- a/crates/lib/tests/gtk-compressed.rs
+++ b/crates/lib/tests/gtk-compressed.rs
@@ -1,0 +1,159 @@
+#[macro_use]
+mod macros;
+
+test!(
+    compresses_simple_rule,
+    "a {\n  color: red;\n}\n",
+    "a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    compresses_rule_with_many_styles,
+    "a {\n  color: red;\n  color: green;\n  color: blue;\n}\n",
+    "a{color:red;color:green;color:blue;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    compresses_media_rule,
+    "@media (foo: bar) {\n  a {\n    color: red;\n  }\n}\n",
+    "@media (foo: bar){a{color:red;}}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    compresses_selector_with_space_after_comma,
+    "a, b {\n  color: red;\n}\n",
+    "a,b{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    compresses_selector_with_newline_after_comma,
+    "a,\nb {\n  color: red;\n}\n",
+    "a,b{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    emits_no_bom_when_compressed,
+    "a {\n  color: 👭;\n}\n",
+    "a{color:👭;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_space_between_selector_combinator,
+    "a > b {\n  color: red;\n}\n",
+    "a>b{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_before_style,
+    "a {\n  /* abc */\n  color: red;\n}\n",
+    "a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_after_style,
+    "a {\n  color: red;\n  /* abc */\n}\n",
+    "a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_between_styles,
+    "a {\n  color: red;\n  /* abc */\n  color: green;\n}\n",
+    "a{color:red;color:green;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_before_ruleset,
+    "/* abc */a {\n  color: red;\n}\n",
+    "a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    keeps_preserved_multiline_comment_before_ruleset,
+    "/*! abc */a {\n  color: red;\n}\n",
+    "/*! abc */a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_after_ruleset,
+    "a {\n  color: red;\n}\n/* abc */",
+    "a{color:red;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_multiline_comment_between_rulesets,
+    "a {\n  color: red;\n}\n/* abc */b {\n  color: green;\n}\n",
+    "a{color:red;}b{color:green;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_spaces_in_comma_separated_list,
+    "a {\n  color: a, b, c;\n}\n",
+    "a{color:a,b,c;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_leading_zero_in_number_under_1,
+    "a {\n  color: 0.5;\n}\n",
+    "a{color:.5;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    removes_leading_zero_in_number_under_1_in_rgba_alpha_channel,
+    "a {\n  color: rgba(1, 1, 1, 0.5);\n}\n",
+    "a{color:rgba(1,1,1,.5);}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    retains_leading_zero_in_opacity,
+    "a {\n  color: opacity(0.5);\n}\n",
+    "a{color:opacity(0.5);}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    retains_leading_zero_in_saturate,
+    "a {\n  color: saturate(0.5);\n}\n",
+    "a{color:saturate(0.5);}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    retains_leading_zero_in_grayscale,
+    "a {\n  color: grayscale(0.5);\n}\n",
+    "a{color:grayscale(0.5);}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    retains_zero_without_decimal,
+    "a {\n  color: 0.0;\n  color: 0;\n}\n",
+    "a{color:0;color:0;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    color_can_be_three_hex,
+    "a {\n  color: white;\n}\n",
+    "a{color:#fff;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    color_cant_be_three_hex_but_hex_is_shorter,
+    "a {\n  color: aquamarine;\n}\n",
+    "a{color:#7fffd4;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    slash_list,
+    "@use 'sass:list'; a {\n  color: list.slash(a, b, c);\n}\n",
+    "a{color:a/b/c;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    retains_space_between_calc_operations,
+    "a {\n  width: calc(100% + 32px);\n}\n",
+    "a{width:calc(100% + 32px);}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);
+test!(
+    cyan_normalized_to_aqua,
+    "a {\n  color: cyan;\n}\n",
+    "a{color:aqua;}",
+    grass::Options::default().style(grass::OutputStyle::GtkCompressed)
+);


### PR DESCRIPTION
Adds a new OutputStyle similar to Compressed designed to work with GTK CSS.

The issue with the current Compressed style when used with GTK CSS is that it
strips semicolons at the end of rule blocks, which GTK doesn't allow leading to
warnings from the parser.

The GtkCompressed style also ensures that no "@charset" or bom is outputted,
since GTK doesn't support them. All GTK CSS is automatically assumed to be
UTF-8. Other encodings are not supported.
